### PR TITLE
Verbose flag for 'help' command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,28 @@ $ make help start
 
 ```
 
+The `-v` verbose flag can be used to display long form for all targets:
+
+```
+$ make help -v
+
+  start:
+    Start the dev server.
+
+    Note that the API server must
+    also be running.
+
+  api:    
+    Start the API server.
+
+  deps:       
+    Display dependency graph.
+
+  size:
+    Display size of dependencies.
+    
+```
+
 The default behaviour of Make is of course preserved:
 
 ```

--- a/cmd/mmake/mmake.go
+++ b/cmd/mmake/mmake.go
@@ -41,7 +41,13 @@ func main() {
 
 	// output target help
 	if len(os.Args) > 2 && os.Args[1] == "help" {
-		err := help.OutputTargetLong(bytes.NewReader(b), os.Stdout, os.Args[2])
+		var err error
+		if os.Args[2] == "-v" {
+			err = help.OutputAllLong(bytes.NewReader(b), os.Stdout)
+		} else {
+			err = help.OutputTargetLong(bytes.NewReader(b), os.Stdout, os.Args[2])
+		}
+
 		if err != nil {
 			log.WithError(err).Fatal("outputting help")
 		}


### PR DESCRIPTION
This resolves Issue #10.

To see how it looks, here's a modified copy of the existing Makefile:

```
# Run all tests.
test:
	@go test -cover ./...
.PHONY: test

# Install the program.
#
# For more details, this is a longer explanation of 
# what install does. I might even list some dependencies
# or trivia about the command.
install:
	@go install ./...
.PHONY: install

# Build release.
build:
	@gox -os="linux darwin windows openbsd" ./...
.PHONY: build
```

And the output it generates:

```
$ mmake help -v

  build:
    Build release.

  install:
    Install the program.
    
    For more details, this is a longer explanation of 
    what install does. I might even list some dependencies
    or trivia about the command.

  test:
    Run all tests.

```

And for comparison, the existing help commands:

```
$ mmake help

  build     Build release.
  install   Install the program.
  test      Run all tests.

$ mmake help install

  Install the program.
  
  For more details, this is a longer explanation of 
  what install does. I might even list some dependencies
  or trivia about the command.

```