### PR TITLE
Add support for help output filtering

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -68,10 +68,24 @@ $ make help
 
 ```
 
-The `help <target>` command is also supported to display long form:
+You can optionally filter which commands to view the help dialogue for (this supports [standard Unix glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)#Syntax)):
 
 ```
 $ make help start
+
+  start   Start the dev server.
+
+$ make help s*
+
+  size    Display size of dependencies.
+  start   Start the dev server.
+
+```
+
+The `help` command also supports displaying longer output with the verbose flag (`-v` / `--verbose`):
+
+```
+$ make help -v start
 
   Start the dev server.
 
@@ -79,8 +93,6 @@ $ make help start
   also be running.
 
 ```
-
-The `-v` verbose flag can be used to display long form for all targets:
 
 ```
 $ make help -v

--- a/cmd/mmake/mmake.go
+++ b/cmd/mmake/mmake.go
@@ -58,23 +58,16 @@ func main() {
 
 // doHelp outputs target comments.
 func doHelp(r io.Reader, args []string) {
-	if len(args) > 0 {
-		var err error
+	var err error
 
-		if args[0] == "-v" {
-			err = help.OutputAllLong(r, os.Stdout)
-		} else {
-			err = help.OutputTargetLong(r, os.Stdout, args[0])
-		}
-
-		if err != nil {
-			log.WithError(err).Fatal("outputting help")
-		}
-		return
+	if len(args) == 0 {
+		err = help.OutputAllShort(r, os.Stdout, []string{})
+	} else if args[0] == "-v" || args[0] == "--verbose" {
+		err = help.OutputAllLong(r, os.Stdout, args[1:])
+	} else {
+		err = help.OutputAllShort(r, os.Stdout, args)
 	}
 
-	// output all help
-	err := help.OutputAllShort(r, os.Stdout)
 	if err != nil {
 		log.WithError(err).Fatal("outputting help")
 	}


### PR DESCRIPTION
For #19.

Replaces `help.OutputTargetLong` by directly filtering targets in `help.getComments`, this means that targets are _automatically_ filtered when outputting (in `help.OutputAllShort` / `help.OutputAllLong`). The consequence with this approach is that the verbose flag is **required** to view long output (this change is highlighted in the README).

Also adds support for using glob patterns in the target filters (this is also highlighted in the README).

Some simple examples:

```make
# Start the dev server.
#
# Note that the API server must
# also be running.
start:
	@gopherjs -m -v serve --http :3000 github.com/tj/docs/client
.PHONY: start

# Display size of dependencies.
size:
	@gopherjs build client/*.go -m -o /tmp/out.js
	@du -h /tmp/out.js
	@gopher-count /tmp/out.js | sort -nr
.PHONY: size
```

```sh
$ mmake help start

  start   Start the dev server.

$ mmake help s?ze

  size   Display size of dependencies.

$ mmake help s*

  size    Display size of dependencies.
  start   Start the dev server.

$ mmake help -v s*

  size:
    Display size of dependencies.

  start:
    Start the dev server.

    Note that the API server must
    also be running.


```