### PR TITLE
Omit comments preceded by a dash

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,6 +47,7 @@ deps:
 .PHONY: deps
 
 # Display size of dependencies.
+#- Any comment preceded by a dash is omitted.
 size:
 	@gopherjs build client/*.go -m -o /tmp/out.js
 	@du -h /tmp/out.js

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -56,9 +56,15 @@ func (p *Parser) advance() string {
 func (p *Parser) bufferComment() {
 	s := p.advance()[1:]
 
-	// leading space
-	if len(s) > 0 && s[0] == ' ' {
-		s = s[1:]
+	if len(s) > 0 {
+		if s[0] == '-' {
+			return
+		}
+
+		// leading space
+		if s[0] == ' ' {
+			s = s[1:]
+		}
 	}
 
 	p.commentBuf = append(p.commentBuf, s)


### PR DESCRIPTION
For #15.

Doesn't buffer any comment that is preceded by a dash (`-`). To omit a target with multiple comments, every comment requires a `-`. Any target with all comments omitted is not displayed in the help dialogue. View examples below.

```make
# Start the dev server.
#
# Note that the API server must
# also be running.
start:
	@gopherjs -m -v serve --http :3000 github.com/tj/docs/client
.PHONY: start

# Start the API server.
api:
	@go run server/cmd/api/api.go
.PHONY: api

#- Display dependency graph.
deps:
	@godepgraph github.com/tj/docs/client | dot -Tsvg | browser
.PHONY: deps

# Display size of dependencies.
#- Any comment preceded by a dash is omitted.
size:
	@gopherjs build client/*.go -m -o /tmp/out.js
	@du -h /tmp/out.js
	@gopher-count /tmp/out.js | sort -nr
.PHONY: size
```

```sh
$ mmake help

  api     Start the API server.
  size    Display size of dependencies.
  start   Start the dev server.

```

```sh
$ mmake help -v start

  start:
    Start the dev server.

    Note that the API server must
    also be running.


```

```sh
$ mmake help -v size

  size:
    Display size of dependencies.


```

```sh
$ mmake help -v deps


```