### PR TITLE
Ignore lines with a .PHONY prefix

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -100,6 +100,8 @@ func (p *Parser) parse() error {
 		switch {
 		case p.i == len(p.lines)-1:
 			return nil
+		case strings.HasPrefix(p.peek(), ".PHONY"):
+			p.advance()
 		case len(p.peek()) == 0:
 			p.pushComment()
 			p.advance()

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -43,6 +43,12 @@ size:
 	@gopher-count /tmp/out.js | sort -nr
 .PHONY: size
 
+.PHONY: dummy
+# Just a comment.
+# Just another comment.
+dummy:
+	@ls
+
 `
 
 	p := parser.New()
@@ -63,6 +69,7 @@ size:
 	// parser.Comment{Target:"api", Value:"Start the API server."}
 	// parser.Comment{Target:"deps", Value:"Display dependency graph."}
 	// parser.Comment{Target:"size", Value:"Display size of dependencies.\n\n- foo\n- bar\n- baz"}
+	// parser.Comment{Target:"dummy", Value:"Just a comment.\nJust another comment."}
 }
 
 func ExampleParser_Parse_withoutComments() {


### PR DESCRIPTION
Hello. This should stop .PHONY lines from showing up in the help output. 
Closes #24 