### PR TITLE
Highlight the default target

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -16,6 +16,7 @@ import (
 // OutputAllShort outputs all short help representations to the given writer.
 func OutputAllShort(r io.Reader, w io.Writer, targets []string) error {
 	comments, err := getComments(r, targets)
+
 	if err != nil {
 		return err
 	}
@@ -27,7 +28,7 @@ func OutputAllShort(r io.Reader, w io.Writer, targets []string) error {
 			continue
 		}
 
-		fmt.Fprintf(w, "  %-*s %-s\n", width+2, c.Target, firstLine(c.Value))
+		printShort(w, c, width)
 	}
 
 	fmt.Fprintf(w, "\n")
@@ -47,7 +48,7 @@ func OutputAllLong(r io.Reader, w io.Writer, targets []string) error {
 			continue
 		}
 
-		fmt.Fprintf(w, "  %-s:\n%-s\n\n", c.Target, indent(indent(c.Value)))
+		printVerbose(w, c)
 	}
 
 	fmt.Fprintf(w, "\n")
@@ -57,6 +58,7 @@ func OutputAllLong(r io.Reader, w io.Writer, targets []string) error {
 // getComments parses, filters, and sorts all comment nodes.
 func getComments(r io.Reader, targets []string) ([]parser.Comment, error) {
 	nodes, err := parser.ParseRecursive(r, "/usr/local/include")
+
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing")
 	}
@@ -116,4 +118,21 @@ func firstLine(s string) string {
 // Indent the given string.
 func indent(s string) string {
 	return strings.Replace("  "+s, "\n", "\n  ", -1)
+}
+
+func printVerbose(w io.Writer, c parser.Comment) (int, error) {
+	if c.Default {
+		c.Value = c.Value + " (default)"
+	}
+
+	return fmt.Fprintf(w, "  %-s:\n%-s\n\n", c.Target, indent(indent(c.Value)))
+}
+
+func printShort(w io.Writer, c parser.Comment, width int) (int, error) {
+	comment := firstLine(c.Value)
+	if c.Default {
+		comment = comment + " (default)"
+	}
+
+	return fmt.Fprintf(w, "  %-*s %-s\n", width+2, c.Target, comment)
 }

--- a/parser/comment.go
+++ b/parser/comment.go
@@ -2,6 +2,7 @@ package parser
 
 // Comment node.
 type Comment struct {
-	Target string
-	Value  string
+	Target  string
+	Value   string
+	Default bool
 }

--- a/parser/funcs.go
+++ b/parser/funcs.go
@@ -16,12 +16,37 @@ func Parse(r io.Reader) ([]Node, error) {
 // ParseRecursive parses the given input recursively
 // relative to the given dir such as /usr/local/include.
 func ParseRecursive(r io.Reader, dir string) ([]Node, error) {
+	nodes, err := parseRecursiveHelper(r, dir)
+
+	for i, _ := range nodes {
+		defaultComment, ok := nodes[i].(Comment)
+		if !ok {
+			continue
+		}
+
+		defaultComment.Default = true
+		nodes[i] = Comment{
+			Target:  defaultComment.Target,
+			Value:   defaultComment.Value,
+			Default: true,
+		}
+		break
+	}
+
+	return nodes, err
+}
+
+func parseRecursiveHelper(r io.Reader, dir string) ([]Node, error) {
 	nodes, err := Parse(r)
+
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing")
 	}
 
+	otherNodes := []Node{}
 	for _, n := range nodes {
+		otherNodes = append(otherNodes, n)
+
 		inc, ok := n.(Include)
 
 		if !ok {
@@ -34,15 +59,16 @@ func ParseRecursive(r io.Reader, dir string) ([]Node, error) {
 			return nil, errors.Wrapf(err, "opening %q", path)
 		}
 
-		more, err := ParseRecursive(f, dir)
+		more, err := parseRecursiveHelper(f, dir)
+
 		if err != nil {
 			return nil, errors.Wrapf(err, "parsing %q", path)
 		}
 
-		nodes = append(nodes, more...)
+		otherNodes = append(otherNodes, more...)
 
 		f.Close()
 	}
 
-	return nodes, nil
+	return otherNodes, nil
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -64,12 +64,12 @@ dummy:
 
 	// Output:
 	// parser.Include{Value:"github.com/tj/foo"}
-	// parser.Comment{Target:"", Value:"Stuff here:\n\n   :)"}
-	// parser.Comment{Target:"start", Value:"Start the dev server."}
-	// parser.Comment{Target:"api", Value:"Start the API server."}
-	// parser.Comment{Target:"deps", Value:"Display dependency graph."}
-	// parser.Comment{Target:"size", Value:"Display size of dependencies.\n\n- foo\n- bar\n- baz"}
-	// parser.Comment{Target:"dummy", Value:"Just a comment.\nJust another comment."}
+	// parser.Comment{Target:"", Value:"Stuff here:\n\n   :)", Default:false}
+	// parser.Comment{Target:"start", Value:"Start the dev server.", Default:false}
+	// parser.Comment{Target:"api", Value:"Start the API server.", Default:false}
+	// parser.Comment{Target:"deps", Value:"Display dependency graph.", Default:false}
+	// parser.Comment{Target:"size", Value:"Display size of dependencies.\n\n- foo\n- bar\n- baz", Default:false}
+	// parser.Comment{Target:"dummy", Value:"Just a comment.\nJust another comment.", Default:false}
 }
 
 func ExampleParser_Parse_withoutComments() {


### PR DESCRIPTION
Hi. This one add the ability to highlight the default target as in #6.

Here is short output:
```
  cloc      Output source statistics. (default)
  install   Install the commands.
  release   Release binaries to GitHub.
  size      Show size of imports.
  test      Run all tests.
  todo      Output to-do items per file.
```

Here is verbose output:
```

  cloc:
    Output source statistics. (default)

  install:
    Install the commands.

  release:
    Release binaries to GitHub.

  size:
    Show size of imports.

  test:
    Run all tests.

  todo:
    Output to-do items per file.

```
Closes #6 