### PR TITLE
Allow using both Makefile and GNUmakefile

### DIFF
--- a/cmd/mmake/mmake.go
+++ b/cmd/mmake/mmake.go
@@ -28,8 +28,18 @@ func main() {
 		cmd = os.Args[1]
 	}
 
+	makefileName := "Makefile"
+	_, err := os.Stat(makefileName)
+	if os.IsNotExist(err) {
+		makefileName = "GNUmakefile"
+	}
+	_, err = os.Stat(makefileName)
+	if os.IsNotExist(err) {
+		log.WithError(err).Fatal("No Makefile (or GNUmakefile) found")
+	}
+
 	// read Makefile
-	b, err := ioutil.ReadFile("Makefile")
+	b, err := ioutil.ReadFile(makefileName)
 	if err != nil {
 		log.WithError(err).Fatal("reading makefile")
 	}


### PR DESCRIPTION
Change the way mmake reads the Makefile.
If Makefile does not exist, it tries GNUmakefile.
If both don't exist, it fails.